### PR TITLE
Add --tee (-t) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ register.
 $
 ```
 
+You can use `vimreg` as `tee` command using `--tee` (`-t`) option.
+It uses `tee` instead of `cat` to receive standard input.
+
+```
+$ vm_stat -c 10 1 | vimreg -t
+```
+
+Note that `vimreg` sends request(s) to vim **after standard input is fully
+received (it doesn't append input to vim register incrementally).**
+That means, if Ctrl-C was pressed before standard input was closed, vimreg
+doesn't sets vim register.
+
+```
+$ while :; do echo 'something heavy task ...'; sleep 1; done | vimreg -t
+something heavy task ...
+something heavy task ...
+something heavy task ...
+^C
+$ # vim register is not updated here!
+```
+
 # Vim --> `:terminal`: get vim register content
 
 `vimreg` supports `--get` or `-g` option.

--- a/macros/vimreg.sh
+++ b/macros/vimreg.sh
@@ -1,9 +1,11 @@
 vimreg() {
-  if ! which jq >/dev/null 2>&1; then
+  if ! command -v jq >/dev/null 2>&1; then
     echo 'error: jq is not installed.' >&2
     return 1
   fi
-  if [ -z "$VIM_TERMINAL" ]; then
+  # shellcheck disable=SC2154
+  if [ -z "${VIM_TERMINAL}" ]; then
+    [ -z "${VIM_TERMINAL}" ]
     echo 'error: you are running vimreg outside vim terminal' >&2
     return 2
   fi
@@ -13,20 +15,21 @@ vimreg() {
   case "$1" in
     --get|-g) get=true; shift ;;
     --list|-l) get=true; reg='--list'; shift ;;
+    *) ;;
   esac
-  [ $reg != '--list' ] && [ $# -gt 0 ] && reg=$1
+  [ "${reg}" != '--list' ] && [ $# -gt 0 ] && reg=$1
 
   local file
   file=$(mktemp -u)
-  if $get; then
-    mkfifo "$file"
-    __call_tapi_reg get "$reg" "$file"
-    cat "$file"
+  if ${get}; then
+    mkfifo "${file}"
+    __call_tapi_reg get "${reg}" "${file}"
+    cat "${file}"
   else
-    cat >"$file"
-    __call_tapi_reg set "$reg" "$file"
+    cat >"${file}"
+    __call_tapi_reg set "${reg}" "${file}"
   fi
-  rm "$file"
+  rm "${file}"
 }
 
 __call_tapi_reg() {
@@ -36,5 +39,5 @@ __call_tapi_reg() {
   cmd=$(echo  -n "$1" | jq -R --slurp .)
   arg1=$(echo -n "$2" | jq -R --slurp .)
   arg2=$(echo -n "$3" | jq -R --slurp .)
-  printf '\e]51;["call","Tapi_reg",[%s,%s,%s]]\x07' "$cmd" "$arg1" "$arg2"
+  printf '\e]51;["call","Tapi_reg",[%s,%s,%s]]\x07' "${cmd}" "${arg1}" "${arg2}"
 }

--- a/macros/vimreg.sh
+++ b/macros/vimreg.sh
@@ -12,9 +12,11 @@ vimreg() {
 
   local get=false
   local reg='"'
+  local tee=false
   case "$1" in
     --get|-g) get=true; shift ;;
     --list|-l) get=true; reg='--list'; shift ;;
+    --tee|-t) tee=true; shift ;;
     *) ;;
   esac
   [ "${reg}" != '--list' ] && [ $# -gt 0 ] && reg=$1
@@ -26,7 +28,11 @@ vimreg() {
     __call_tapi_reg get "${reg}" "${file}"
     cat "${file}"
   else
-    cat >"${file}"
+    if ${tee}; then
+      tee "${file}"
+    else
+      cat >"${file}"
+    fi
     __call_tapi_reg set "${reg}" "${file}"
   fi
   rm "${file}"


### PR DESCRIPTION
This option uses `tee` command instead of `cat` command to receive standard input.

![tapi-reg-tee](https://user-images.githubusercontent.com/48169/76762955-98f35400-67d5-11ea-8773-30898f2071d1.gif)
